### PR TITLE
Add zonal affinity to L4 load balancer metrics

### DIFF
--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -605,7 +605,8 @@ func (l4c *L4Controller) publishMetrics(result *loadbalancers.L4ILBSyncResult, n
 		l4c.ctx.ControllerMetrics.SetL4ILBServiceForLegacyMetric(namespacedName, result.MetricsLegacyState)
 		l4c.ctx.ControllerMetrics.SetL4ILBService(namespacedName, result.MetricsState)
 		isWeightedLB := result.MetricsState.WeightedLBPodsPerNode
-		l4metrics.PublishILBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime, isResync, isWeightedLB)
+		isZonalAffinityLB := result.MetricsState.ZonalAffinity
+		l4metrics.PublishILBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime, isResync, isWeightedLB, isZonalAffinityLB)
 		if l4c.enableDualStack {
 			svcLogger.V(2).Info("Internal L4 DualStack Loadbalancer for Service ensured, updating its state in metrics cache", "serviceState", result.MetricsState)
 			l4metrics.PublishL4ILBDualStackSyncLatency(result.Error == nil, result.SyncType, result.MetricsState.IPFamilies, result.StartTime, isResync)
@@ -623,7 +624,8 @@ func (l4c *L4Controller) publishMetrics(result *loadbalancers.L4ILBSyncResult, n
 			l4c.ctx.ControllerMetrics.DeleteL4ILBService(namespacedName)
 		}
 		isWeightedLB := result.MetricsState.WeightedLBPodsPerNode
-		l4metrics.PublishILBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime, false, isWeightedLB)
+		isZonalAffinityLB := result.MetricsState.ZonalAffinity
+		l4metrics.PublishILBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime, false, isWeightedLB, isZonalAffinityLB)
 		if l4c.enableDualStack {
 			l4metrics.PublishL4ILBDualStackSyncLatency(result.Error == nil, result.SyncType, result.MetricsState.IPFamilies, result.StartTime, false)
 		}

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -102,12 +102,15 @@ func NewL4SyncResult(syncType string, svc *corev1.Service, isMultinet bool, enab
 		backendType = metrics.L4BackendTypeNEG
 	}
 
+	// External Load Balancer doesn't support zonal affinity (passing `false` all along)
+	isLBWithZonalAffinity := false
+
 	result := &L4NetLBSyncResult{
 		Annotations:        make(map[string]string),
 		StartTime:          startTime,
 		SyncType:           syncType,
 		MetricsLegacyState: metrics.InitL4NetLBServiceLegacyState(&startTime),
-		MetricsState:       metrics.InitServiceMetricsState(svc, &startTime, isMultinet, enabledStrongSessionAffinity, isWeightedLBPodsPerNode, backendType),
+		MetricsState:       metrics.InitServiceMetricsState(svc, &startTime, isMultinet, enabledStrongSessionAffinity, isWeightedLBPodsPerNode, isLBWithZonalAffinity, backendType),
 	}
 	return result
 }

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -75,6 +75,8 @@ type L4FeaturesServiceLabels struct {
 	WeightedLBPodsPerNode bool
 	// BackendType is the type of the backend the LB uses (IGs or NEGs).
 	BackendType L4BackendType
+	// ZonalAffinity is true if Zonal Affinity is enabled
+	ZonalAffinity bool
 }
 
 // L4ServiceState tracks the state of an L4 service. It includes data needed to fill various L4 metrics plus the status of the service.


### PR DESCRIPTION
Add zonal_affinity label to L4 ILB and NetLB metrics to track usage of traffic distribution zonal affinity feature. Update corresponding test functions to verify the new metric labels.